### PR TITLE
Update rws.js

### DIFF
--- a/rws.js
+++ b/rws.js
@@ -16,7 +16,7 @@ export default class RWS extends EventEmitter {
     this.url = url;
     this.protocols = protocols;
     for (const setting in settings) {
-      this[setting] = options[setting] || settings[setting];
+      this[setting] = setting in options ? options[setting] : settings[setting];
     }
 
     this.ws = null;


### PR DESCRIPTION
allow falsy options to be passed

---

before, it would not set any falsy option (eg. if you wanted to set `automaticOpen` to `false`, it would NOT do that)
